### PR TITLE
Added missing Mode (nr 2)

### DIFF
--- a/mikettle/mikettle.py
+++ b/mikettle/mikettle.py
@@ -39,6 +39,7 @@ MI_ACTION_MAP = {
 MI_MODE_MAP = {
     255: "none",
     1: "boil",
+    2: "re-boil",
     3: "keep warm"
 }
 


### PR DESCRIPTION
I think it's the mode set up after kettle is turned to "warm" mode, emptied and then refilled with cold water. The kettle boils the water again and stays in "warm" mode. 

Without this parameter, the data cannot be parsed and demo.py doesn't work.